### PR TITLE
log4cxx: keep in-source build to avoid removal log4cxx.h

### DIFF
--- a/recipes-support/log4cxx/log4cxx_0.10.0.bb
+++ b/recipes-support/log4cxx/log4cxx_0.10.0.bb
@@ -13,7 +13,7 @@ SRC_URI = "http://archive.apache.org/dist/logging/log4cxx/0.10.0/apache-log4cxx-
 
 S = "${WORKDIR}/apache-${PN}-${PV}"
 
-inherit autotools pkgconfig
+inherit autotools-brokensep pkgconfig
 
 SRC_URI[md5sum] = "b30ffb8da3665178e68940ff7a61084c"
 SRC_URI[sha256sum] = "0de0396220a9566a580166e66b39674cb40efd2176f52ad2c65486c99c920c8c"


### PR DESCRIPTION
The autotools-brokensep indicates that the log4cxx currently cannot
handle out-of-source builds, and hence the in-source build must be
kept until this is resolved.

There might be situations when other layers might want to use log4cxx
provided by meta-intel-realsense, but the current recipe doesn't
install the header log4cxx/log4cxx.h included by e.g.
log4cxx/logstring.h which is a part of public API. Thus this patch.

Signed-off-by: Dmitry Rozhkov dmitry.rozhkov@linux.intel.com
