### PR TITLE
librealsense: update version and fix DISTRO_FEATURES

### DIFF
--- a/recipes-support/librealsense/librealsense.inc
+++ b/recipes-support/librealsense/librealsense.inc
@@ -4,21 +4,26 @@ SECTION = "libs"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
-DEPENDS = "libpng libusb1 libglu glfw"
+DEPENDS = "libusb1"
+DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'libpng libglu glfw', '', d)}"
 RDEPENDS_${PN} = "bash"
 RDEPENDS_${PN}-examples += "${PN}"
 RDEPENDS_${PN}-graphical-examples += "${PN} libgl-mesa"
 
 inherit cmake pkgconfig
 
-EXTRA_OECMAKE = "-DBUILD_SHARED_LIBS:BOOL=ON -DBUILD_EXAMPLES:BOOL=ON -DBUILD_UNIT_TESTS:BOOL=OFF"
+EXTRA_OECMAKE = " \
+	-DBUILD_SHARED_LIBS:BOOL=ON -DBUILD_UNIT_TESTS:BOOL=OFF \
+	-DBUILD_EXAMPLES:BOOL=${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'ON', 'OFF', d)} \
+"
 
 do_install_append() {
 	install -d "${D}${sysconfdir}/udev/rules.d"
 	install -m 0644 ${S}/config/99-realsense-libusb.rules ${D}${sysconfdir}/udev/rules.d
 }
 
-PACKAGES = "${PN} ${PN}-dbg ${PN}-dev ${PN}-examples ${PN}-graphical-examples"
+PACKAGES = "${PN} ${PN}-dbg ${PN}-dev"
+PACKAGES += "${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', '${PN}-examples ${PN}-graphical-examples', '', d)}"
 
 FILES_${PN} = "\
 	${libdir}/*.so.* \


### PR DESCRIPTION
Having a direct dependency to libglu requires x11 DISTRO_FEATURE to be turned on. However, x11 support is only needed for compiling the examples. Change the recipe so that compiling the examples only happens when both x11 and opengl DISTRO_FEATUREs are enabled.

Also update the recipe to the latest librealsense. Cmake compilation doesn't succeed otherwise, because the ROS build environment check is missing still from version 1.10.0.
