### PR TITLE
librealsense2: Remove extra dash in libuvc option

### DIFF
--- a/recipes-support/librealsense/librealsense2_2.33.1.bb
+++ b/recipes-support/librealsense/librealsense2_2.33.1.bb
@@ -44,7 +44,7 @@ PACKAGES += "\
 PACKAGES += "${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', '${PN}-graphical-examples', '', d)}"
 
 PACKAGECONFIG ??= ""
-PACKAGECONFIG[rsusb] = "-DFORCE_RSUSB_BACKEND:BOOL=ON,--DFORCE_RSUSB_BACKEND:BOOL=OFF"
+PACKAGECONFIG[rsusb] = "-DFORCE_RSUSB_BACKEND:BOOL=ON,-DFORCE_RSUSB_BACKEND:BOOL=OFF"
 
 do_install_append() {
     install -d "${D}${sysconfdir}/udev/rules.d"


### PR DESCRIPTION
This fixes the following error I received today:
```
ERROR: librealsense2-2.33.1-r0 do_configure: Execution of '/home/ubuntu/eval-workspace/build/tmp/work/aarch64-fsl-linux/librealsense2/2.33.1-r0/temp/run.do_configure.3128642' failed with exit code 1:                                         
CMake Error: The source directory "/home/ubuntu/eval-workspace/build/tmp/work/aarch64-fsl-linux/librealsense2/2.33.1-r0/build/--DFORCE_RSUSB_BACKEND:BOOL=OFF" does not exist.                                                                  
Specify --help for usage, or press the help button on the CMake GUI.                                                    
WARNING: exit code 1 from a shell command. 
```