### PR TITLE
conf: only modify intel-kernel when meta-intel layer exists

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -3,7 +3,10 @@ BBPATH .= ":${LAYERDIR}"
 
 # We have a recipes directory, add to BBFILES
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
-	    ${LAYERDIR}/recipes-*/*/*.bbappend"
+	    ${LAYERDIR}/recipes-support/*/*.bbappend \
+	    ${LAYERDIR}/recipes-kernel/*/*yocto*.bbappend"
+
+BBFILES_DYNAMIC += "meta-intel:${LAYERDIR}/recipes-kernel/*/*intel*.bbappend"
 
 BBFILE_COLLECTIONS += "intel-realsense"
 BBFILE_PATTERN_intel-realsense:= "^${LAYERDIR}/"
@@ -11,5 +14,3 @@ BBFILE_PRIORITY_intel-realsense = "6"
 
 LAYERSERIES_COMPAT_intel-realsense = "langdale kirkstone"
 LAYERDEPENDS_intel-realsense = "openembedded-layer"
-
-BB_DANGLINGAPPENDS_WARNONLY ?= "true"


### PR DESCRIPTION
When meta-intel is not included yocto gives the following warning with meta-intel-realsense included

```
WARNING: No recipes in default available for:
 ../meta-intel-realsense/recipes-kernel/linux/linux-intel-rt_5.10.bbappend
 ../meta-intel-realsense/recipes-kernel/linux/linux-intel-rt_5.15.bbappend
 ../meta-intel-realsense/recipes-kernel/linux/linux-intel_5.10.bbappend
 ../meta-intel-realsense/recipes-kernel/linux/linux-intel_5.15.bbappend
```

Avoid this by dynamically including the bbappends for linux-intel. This with these warnings gone, remove `BB_DANGLINGAPPENDS_WARNONLY ?= "1"` as well.

Signed-off-by: Aske Baekdal Moeller <aske@geanix.com>