### PR TITLE
Fix grammar in readme. (python section)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ If you are building an image with a graphical desktop you can also add the follo
 ```
 
 ### Python
-To include Python support in your image include the following in your `conf/auto.conf`
+To include Python support in your image, include the following in your `conf/auto.conf`
 
 ```bitbake
     CORE_IMAGE_EXTRA_INSTALL += "python3-pyrealsense2"


### PR DESCRIPTION
Was reading over the line "To include Python support in your image include the following in your `conf/auto.conf`" but I noticed near the words "image include" there was no comma even though there should be.